### PR TITLE
 민감 정보인 Database 연결 정보를 환경변수에서 가져오도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,7 @@ dependencies {
     testCompile('com.h2database:h2')
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+bootRun {
+    systemProperty 'spring.profiles.active', 'localhost'
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,9 +4,9 @@
 # MySQL Database
 # deploy시 import.sql의 한글깨짐 방지
 spring.datasource.sql-script-encoding= UTF-8
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/MAPC?useUnicode=true&charaterEncoding=utf-8&useSSL=false
-spring.datasource.username=mapc_db
-spring.datasource.password=mapc_db1234
+spring.datasource.url=jdbc:mysql://${MAPC_DB_URL}?useUnicode=true&characterEncoding=UTF-8&useSSL=false
+spring.datasource.username=${MAPC_DB_USERNAME}
+spring.datasource.password=${MAPC_DB_PASSWORD}
 spring.datasource.type=com.zaxxer.hikari.HikariDataSource
 spring.datasource.hikari.pool-name==MapCHikariCP
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver


### PR DESCRIPTION
## Description
* 민감 정보인 Database 연결 정보를 환경변수에서 가져오도록 수정했어요
* 환경변수랑 gradle.properties랑 고려해봤는데, gradle.properties도 결국 파일로 git에 올라가면 민감정보가 노출되니깐 환경변수로 사용하도록 수정했어요
* 아직 EC2에서 환경변수 셋팅해서는 test 못해봤구요
```sh
$ java -jar <jar name> --MAPC_DB_URL=127.0.0.1:3306/MAPC --MAPC_DB_USERNAME=mapc_db --MAPC_DB_PASSWORD=mapc_db1234
```
* 위처럼 jar 실행시에 입력하는 주는걸로는 테스트 해봤어요

<img width="779" alt="2018-08-25 1 11 24" src="https://user-images.githubusercontent.com/8637090/44596353-bd0fce80-a806-11e8-8783-952746cf5889.png">
* IntelliJ에서는 위 이미지에 표시해놓은 부분에 셋팅해놓으시면되요

## Related Tickets
* 개발 진행을 위한 code base의 사전 작업하기(#35)
* Feature/is34 jpa entity modeling(#41)

<br>

> #### Reference
> 없습니다

---

<br>

## Check List
- [x] PR 제목은 유의미한가?
- [x] PR 내용만 보고도 이해할 수 있을 정도로 기술되었는가?
- [x] 관련 issue를 적었는가?
- [ ] 관련 reference가 있다면 함께 적었는가?
- [x] Reviewer, Assginess, Label을 지정했는가?
